### PR TITLE
Implement Supabase Social Logins (Google & GitHub)

### DIFF
--- a/app/pages/(auth)/login.vue
+++ b/app/pages/(auth)/login.vue
@@ -7,6 +7,7 @@ definePageMeta({
 })
 
 const supabase = useSupabaseClient()
+const requestURL = useRequestURL()
 const toast = useToast()
 
 const fields = [{
@@ -21,28 +22,49 @@ const fields = [{
 	placeholder: 'Enter your password',
 }]
 
+async function onOAuthLogin(provider: 'Google' | 'GitHub') {
+	const providerName = provider.charAt(0).toUpperCase() + provider.slice(1)
+	
+	const pending = toast.add({ 
+		title: `Redirecting to ${providerName}...`, 
+		color: 'info', 
+		icon: 'i-lucide-loader', 
+		duration: 0 
+	})
+	
+	const { error } = await supabase.auth.signInWithOAuth({
+		provider: provider.toLowerCase() as 'google' | 'github',
+		options: {
+			redirectTo: `${requestURL.origin}/me`
+		}
+	})
+	
+	toast.remove(pending.id)
+	
+	if (error) {
+		toast.add({ 
+			title: `Error with ${providerName} login`, 
+			description: error.message, 
+			color: 'error', 
+			icon: 'i-lucide-triangle-alert' 
+		})
+	} else {
+		toast.add({ 
+			title: `Successfully logged in with ${providerName}!`, 
+			color: 'success', 
+			icon: 'i-lucide-check' 
+		})
+	}
+}
+
 const providers = [{
 	label: 'Google',
 	icon: 'i-simple-icons-google',
-	onClick: () => {
-		supabase.auth.signInWithOAuth({
-			provider: 'google',
-			options: {
-				redirectTo:  `${useRequestURL().origin}/me`
-			}
-		})
-	}
+	onClick: () => onOAuthLogin('Google')
 }, {
 	label: 'GitHub',
 	icon: 'i-simple-icons-github',
-	onClick: () => {
-		supabase.auth.signInWithOAuth({
-			provider: 'github',
-			options: {
-				redirectTo: `${useRequestURL().origin}/me`
-			}
-		})
-	}
+	onClick: () => onOAuthLogin('GitHub')
 }]
 
 const loading = ref(false)
@@ -99,7 +121,7 @@ async function onForgotPassword(payload: FormSubmitEvent<SchemaResetPassword>) {
 	loading.value = true
 
 	const { error } = await supabase.auth.resetPasswordForEmail(payload.data.email, {
-		redirectTo: `${useRequestURL().origin}/reset-password`
+		redirectTo: `${requestURL.origin}/reset-password`
 	})
 
 	toast.remove(pending.id)

--- a/app/pages/(auth)/login.vue
+++ b/app/pages/(auth)/login.vue
@@ -146,6 +146,8 @@ const verifyEmailModalOpen = ref(freshlyRegisteredEmail !== undefined)
 					icon="i-lucide-user"
 					@submit="onSubmit">
 				<template #description>
+					Enter your credentials to access your account.
+					<br>
 					Don't have an account?
 					<ULink to="/register" class="text-primary font-medium">Register here</ULink>.
 				</template>

--- a/app/pages/(auth)/login.vue
+++ b/app/pages/(auth)/login.vue
@@ -6,6 +6,7 @@ definePageMeta({
 	middleware: ["logged-out"]
 })
 
+const supabase = useSupabaseClient()
 const toast = useToast()
 
 const fields = [{
@@ -18,6 +19,30 @@ const fields = [{
 	label: 'Password',
 	type: 'password' as const,
 	placeholder: 'Enter your password',
+}]
+
+const providers = [{
+	label: 'Google',
+	icon: 'i-simple-icons-google',
+	onClick: () => {
+		supabase.auth.signInWithOAuth({
+			provider: 'google',
+			options: {
+				redirectTo: 'http://localhost:3000/me'
+			}
+		})
+	}
+}, {
+	label: 'GitHub',
+	icon: 'i-simple-icons-github',
+	onClick: () => {
+		supabase.auth.signInWithOAuth({
+			provider: 'github',
+			options: {
+				redirectTo: 'http://localhost:3000/me'
+			}
+		})
+	}
 }]
 
 const loading = ref(false)
@@ -33,7 +58,7 @@ async function onSubmit(payload: FormSubmitEvent<SchemaLogin>) {
 	const pending = toast.add({ title: 'Logging in...', color: 'info', icon: 'i-lucide-loader', duration: 0 })
 	loading.value = true
 
-	const { error } = await useSupabaseClient().auth.signInWithPassword({
+	const { error } = await supabase.auth.signInWithPassword({
 		email: payload.data.email,
 		password: payload.data.password,
 	})
@@ -73,7 +98,7 @@ async function onForgotPassword(payload: FormSubmitEvent<SchemaResetPassword>) {
 	})
 	loading.value = true
 
-	const { error } = await useSupabaseClient().auth.resetPasswordForEmail(payload.data.email, {
+	const { error } = await supabase.auth.resetPasswordForEmail(payload.data.email, {
 		redirectTo: 'http://localhost:3000/reset-password'
 	})
 
@@ -141,6 +166,7 @@ const verifyEmailModalOpen = ref(freshlyRegisteredEmail !== undefined)
 			<UAuthForm
 					:schema="schemaLogin"
 					:fields="fields"
+					:providers="providers"
 					:loading="loading"
 					title="Welcome back!"
 					icon="i-lucide-user"

--- a/app/pages/(auth)/login.vue
+++ b/app/pages/(auth)/login.vue
@@ -28,7 +28,7 @@ const providers = [{
 		supabase.auth.signInWithOAuth({
 			provider: 'google',
 			options: {
-				redirectTo: 'http://localhost:3000/me'
+				redirectTo:  `${useRequestURL().origin}/me`
 			}
 		})
 	}
@@ -39,7 +39,7 @@ const providers = [{
 		supabase.auth.signInWithOAuth({
 			provider: 'github',
 			options: {
-				redirectTo: 'http://localhost:3000/me'
+				redirectTo: `${useRequestURL().origin}/me`
 			}
 		})
 	}
@@ -99,7 +99,7 @@ async function onForgotPassword(payload: FormSubmitEvent<SchemaResetPassword>) {
 	loading.value = true
 
 	const { error } = await supabase.auth.resetPasswordForEmail(payload.data.email, {
-		redirectTo: 'http://localhost:3000/reset-password'
+		redirectTo: `${useRequestURL().origin}/reset-password`
 	})
 
 	toast.remove(pending.id)

--- a/app/pages/(auth)/login.vue
+++ b/app/pages/(auth)/login.vue
@@ -23,10 +23,8 @@ const fields = [{
 }]
 
 async function onOAuthLogin(provider: 'Google' | 'GitHub') {
-	const providerName = provider.charAt(0).toUpperCase() + provider.slice(1)
-	
-	const pending = toast.add({ 
-		title: `Redirecting to ${providerName}...`, 
+	const pending = toast.add({
+		title: `Redirecting to ${provider}...`,
 		color: 'info', 
 		icon: 'i-lucide-loader', 
 		duration: 0 
@@ -43,14 +41,14 @@ async function onOAuthLogin(provider: 'Google' | 'GitHub') {
 	
 	if (error) {
 		toast.add({ 
-			title: `Error with ${providerName} login`, 
+			title: `Error with ${provider} login`,
 			description: error.message, 
 			color: 'error', 
 			icon: 'i-lucide-triangle-alert' 
 		})
 	} else {
 		toast.add({ 
-			title: `Successfully logged in with ${providerName}!`, 
+			title: `Successfully logged in with ${provider}!`,
 			color: 'success', 
 			icon: 'i-lucide-check' 
 		})

--- a/app/pages/(auth)/login.vue
+++ b/app/pages/(auth)/login.vue
@@ -23,7 +23,7 @@ const fields = [{
 }]
 
 async function onOAuthLogin(provider: 'Google' | 'GitHub') {
-	const pending = toast.add({
+	toast.add({
 		title: `Redirecting to ${provider}...`,
 		color: 'info', 
 		icon: 'i-lucide-loader', 
@@ -33,11 +33,9 @@ async function onOAuthLogin(provider: 'Google' | 'GitHub') {
 	const { error } = await supabase.auth.signInWithOAuth({
 		provider: provider.toLowerCase() as 'google' | 'github',
 		options: {
-			redirectTo: `${requestURL.origin}/me`
+			redirectTo: `${requestURL.origin}/me?oAuthStatus=${btoa('oauth_success:' + provider)}`,
 		}
 	})
-	
-	toast.remove(pending.id)
 	
 	if (error) {
 		toast.add({ 
@@ -45,12 +43,6 @@ async function onOAuthLogin(provider: 'Google' | 'GitHub') {
 			description: error.message, 
 			color: 'error', 
 			icon: 'i-lucide-triangle-alert' 
-		})
-	} else {
-		toast.add({ 
-			title: `Successfully logged in with ${provider}!`,
-			color: 'success', 
-			icon: 'i-lucide-check' 
 		})
 	}
 }

--- a/app/pages/(auth)/register.vue
+++ b/app/pages/(auth)/register.vue
@@ -90,11 +90,13 @@ async function onSubmit(payload: FormSubmitEvent<SchemaRegister>) {
 					:schema="schemaRegister"
 					:fields="fields"
 					:loading="loading"
-					title="Register"
+					title="Create an account!"
 					icon="i-lucide-user-plus"
 					@submit="onSubmit"
 			>
 				<template #description>
+					Enter your credentials to create an account.
+					<br>
 					Already have an account?
 					<ULink to="/login" class="text-primary font-medium">Login here</ULink>.
 				</template>

--- a/app/pages/(user)/me.vue
+++ b/app/pages/(user)/me.vue
@@ -1,5 +1,36 @@
 <script setup lang="ts">
+const route = useRoute()
+const toast = useToast()
 
+// Check for OAuth success
+onMounted(() => {
+	const oAuthStatus = route.query.oAuthStatus as string
+	if (oAuthStatus) {
+		try {
+			const decoded = atob(oAuthStatus)
+			const [prefix, provider] = decoded.split(':')
+
+			if (prefix === 'oauth_success' && provider) {
+				toast.add({
+					title: `Successfully logged in with ${provider}!`,
+					color: 'success',
+					icon: 'i-lucide-check'
+				})
+
+				// Clean up the URL
+				navigateTo('/me', { replace: true })
+			}
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		} catch (error) {
+			toast.add({
+				title: 'Error with OAuth login',
+				description: 'Invalid OAuth status',
+				color: 'error',
+				icon: 'i-lucide-triangle-alert'
+			})
+		}
+	}
+})
 </script>
 
 <template>


### PR DESCRIPTION
This pull request adds support for social login via Google and GitHub to the login page, improves code consistency by reusing the Supabase client, and updates the UI descriptions for both login and registration forms to provide clearer guidance to users.

**Authentication improvements:**

* Added a `providers` array to the login page, enabling users to sign in with Google or GitHub using Supabase OAuth, with appropriate redirect handling.
* Enabled Supabase Authentication Providers Google and GitHub
* Created OAuth apps/projects for Google and GitHub respectively, in order to enable the authentication of these 2 social provider via Supabase.

**UI/UX enhancements:**

* Passed the new `providers` array to the `UAuthForm` component, enabling social login buttons in the UI.
* Updated the description text in both login and registration forms to provide clearer instructions for users.
* Changed the registration form title from "Register" to "Create an account!" for a more inviting user experience.

This PR resolves #40 