### PR TITLE
Refine fresh registration using store variable

### DIFF
--- a/app/pages/(auth)/login.vue
+++ b/app/pages/(auth)/login.vue
@@ -94,6 +94,11 @@ async function onForgotPassword(payload: FormSubmitEvent<SchemaResetPassword>) {
 
 const freshRegister = useState<string | undefined>("freshRegister")
 const verifyEmailModalOpen = ref(freshRegister.value !== undefined)
+
+function onUnderstoodVerify() {
+	verifyEmailModalOpen.value = false
+	setTimeout(() => freshRegister.value = undefined, 300)
+}
 </script>
 
 <template>
@@ -129,7 +134,7 @@ const verifyEmailModalOpen = ref(freshRegister.value !== undefined)
 					<p class="text-sm text-muted text-center">
 						Before being able to use your account, you need to verify your email address. We sent you an email to <span class="text-primary">{{ freshRegister || '??' }}</span>. Please click the link in the email to verify your account.
 					</p>
-					<UButton class="mt-2" label="Understood" @click="freshRegister = undefined; verifyEmailModalOpen = false"/>
+					<UButton class="mt-2" label="Understood" @click="onUnderstoodVerify"/>
 				</div>
 			</template>
 		</UModal>

--- a/app/pages/(auth)/login.vue
+++ b/app/pages/(auth)/login.vue
@@ -92,8 +92,8 @@ async function onForgotPassword(payload: FormSubmitEvent<SchemaResetPassword>) {
 	}
 }
 
-const freshlyRegisteredEmail = useRoute().query.freshlyRegisteredEmail as string | undefined
-const verifyEmailModalOpen = ref(freshlyRegisteredEmail !== undefined)
+const freshRegister = useState<string | undefined>("freshRegister")
+const verifyEmailModalOpen = ref(freshRegister.value !== undefined)
 </script>
 
 <template>
@@ -127,9 +127,9 @@ const verifyEmailModalOpen = ref(freshlyRegisteredEmail !== undefined)
 					<UIcon name="i-lucide-circle-alert" class="text-4xl text-(--ui-warning)"/>
 					<h3 class="font-medium text-lg">Verify your email</h3>
 					<p class="text-sm text-muted text-center">
-						Before being able to use your account, you need to verify your email address. We sent you an email to <span class="text-primary">{{ freshlyRegisteredEmail || '??' }}</span>. Please click the link in the email to verify your account.
+						Before being able to use your account, you need to verify your email address. We sent you an email to <span class="text-primary">{{ freshRegister || '??' }}</span>. Please click the link in the email to verify your account.
 					</p>
-					<UButton class="mt-2" label="Understood" @click="verifyEmailModalOpen = false"/>
+					<UButton class="mt-2" label="Understood" @click="freshRegister = undefined; verifyEmailModalOpen = false"/>
 				</div>
 			</template>
 		</UModal>

--- a/app/pages/(auth)/register.vue
+++ b/app/pages/(auth)/register.vue
@@ -67,7 +67,7 @@ async function onSubmit(payload: FormSubmitEvent<SchemaRegister>) {
 			title: 'Successfully created account!',
 			description: 'To use your account, please verify your email.',
 			color: 'warning',
-			icon: 'i-lucide-check',
+			icon: 'i-lucide-mail',
 			duration: 10000
 		})
 		useState<string | undefined>("freshRegister").value = payload.data.email

--- a/app/pages/(auth)/register.vue
+++ b/app/pages/(auth)/register.vue
@@ -70,12 +70,8 @@ async function onSubmit(payload: FormSubmitEvent<SchemaRegister>) {
 			icon: 'i-lucide-check',
 			duration: 10000
 		})
-		navigateTo({
-			path: '/login',
-			query: {
-				freshlyRegisteredEmail: payload.data.email
-			}
-		})
+		useState<string | undefined>("freshRegister").value = payload.data.email
+		navigateTo({ path: '/login' })
 	}
 }
 </script>


### PR DESCRIPTION
This pull request updates the user registration and login flows to improve how the freshly registered email state is managed and displayed. Instead of passing the email via query parameters, the code now uses a shared state for a more robust and maintainable approach. The modal logic for email verification is also streamlined.

**Improvements to registration and login flows:**

* Replaced the use of the `freshlyRegisteredEmail` query parameter with a shared state variable `freshRegister` to track the freshly registered email across navigation. (`app/pages/(auth)/register.vue`, `app/pages/(auth)/login.vue`)
* Updated the email verification modal to use the `freshRegister` state and improved its dismissal logic by resetting the state after the modal is closed. (`app/pages/(auth)/login.vue`)
* Changed the notification icon shown after registration from a checkmark to a mail icon for better user feedback. (`app/pages/(auth)/register.vue`)
* Updated the modal message to reference `freshRegister` instead of the query parameter, ensuring the correct email is displayed. (`app/pages/(auth)/login.vue`)
* Replaced direct modal closure with an event handler (`onUnderstoodVerify`) that also clears the shared state after a short delay. (`app/pages/(auth)/login.vue`)