### PR TITLE
Add signup confirmation information

### DIFF
--- a/app/pages/(user)/me.vue
+++ b/app/pages/(user)/me.vue
@@ -1,9 +1,33 @@
 <script setup lang="ts">
+const route = useRoute()
+const toast = useToast()
 
+const signupSuccessModalOpen = ref(false)
+
+// Check for successful signup confirmation
+onMounted(() => {
+    const signup = route.query.signup as string
+    if (signup === 'true') {
+        signupSuccessModalOpen.value = true
+        // Clean up the URL
+        navigateTo('/me', { replace: true })
+    }
+})
 </script>
 
 <template>
-
+    <UModal v-model:open="signupSuccessModalOpen">
+        <template #content>
+            <div class="flex flex-col h-full items-center justify-center gap-4 p-8">
+                <UIcon name="i-lucide-check-circle" class="text-4xl text-(--ui-success)"/>
+                <h3 class="font-medium text-lg">Account Confirmed!</h3>
+                <p class="text-sm text-muted text-center">
+                    Your email address has been confirmed. You are now able to use your account.
+                </p>
+                <UButton class="mt-2" label="Understood" @click="signupSuccessModalOpen = false"/>
+            </div>
+        </template>
+    </UModal>
 </template>
 
 <style scoped>

--- a/app/pages/(user)/me.vue
+++ b/app/pages/(user)/me.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
 const route = useRoute()
-const toast = useToast()
-
 const signupSuccessModalOpen = ref(false)
 
 // Check for successful signup confirmation


### PR DESCRIPTION
This pull request enhances the user experience on the account page by adding a modal to confirm successful email verification after signup. When the page detects a successful signup via the URL query parameter, it displays a modal with a confirmation message and cleans up the URL.

User experience improvements:

* Added logic to detect a successful signup confirmation using the `signup` query parameter and display a modal when appropriate.
* Implemented a `UModal` component that shows a success icon, confirmation message, and an "Understood" button to dismiss the modal.
* Automatically cleans up the URL by removing the query parameter after showing the modal, ensuring a cleaner navigation experience.

Resolves #84 